### PR TITLE
Fix Event Generation #2. Added 2 new events and extra error details

### DIFF
--- a/src/main/java/com/joebotics/simmer/client/integration/JSEventBusProxy.java
+++ b/src/main/java/com/joebotics/simmer/client/integration/JSEventBusProxy.java
@@ -1,7 +1,11 @@
 package com.joebotics.simmer.client.integration;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import com.joebotics.simmer.client.elcomp.AbstractCircuitElement;
+import com.joebotics.simmer.client.elcomp.CircuitNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,15 +28,49 @@ public class JSEventBusProxy {
 	}-*/;
 
     public static native void bind(String pattern, Handler handler) /*-{
-        $wnd.busInSimmer.bind(pattern, $entry(handler));
+    	if ($wnd.busInSimmer) {
+        	$wnd.busInSimmer.bind(pattern, $entry(handler));
+        }
     }-*/;
 
-    public static native void fire(String evt, JSONObject data) /*-{
-        var model = eval("(" + data + ")");
-        evt.model = model;
-        $wnd.busInSimmer.fire(evt, {model: model});
+    private static native void fire(String evt, JSONObject data) /*-{
+        if ($wnd.busInSimmer) {
+	        var model = eval("(" + data + ")");
+	        evt.model = model;
+	        $wnd.busInSimmer.fire(evt, {model: model});
+	    }
     }-*/;
-
+    
+    public static void fireEvent(SimmerEvents evt, JSONObject data) {
+    	fire(evt.value, data);
+    }
+    
+    public static void fireError(SimmerEvents evt, String message) {
+    	JSONObject data = new JSONObject();
+    	data.put("message", new JSONString(message));
+    	fire(evt.value, data);
+    }
+    
+    public static void fireError(SimmerEvents evt, String message, AbstractCircuitElement ce) {
+    	JSONObject data = new JSONObject();
+    	data.put("message", new JSONString(message));
+    	if (ce != null) {
+    		data.put("element", new JSONString(ce.toString()));
+    	}
+    	fire(evt.value, data);
+    }
+    
+    public static void fireError(SimmerEvents evt, String message, CircuitNode node) {
+    	JSONObject data = new JSONObject();
+    	data.put("message", new JSONString(message));
+    	if (node != null) {
+	        JSONObject obj = new JSONObject();
+	        obj.put("x", new JSONNumber(node.x));
+	        obj.put("y", new JSONNumber(node.y));
+	    	data.put("node", obj);
+    	}
+    	fire(evt.value, data);
+    }
 }
 
 

--- a/src/main/java/com/joebotics/simmer/client/integration/SimmerEvents.java
+++ b/src/main/java/com/joebotics/simmer/client/integration/SimmerEvents.java
@@ -16,7 +16,9 @@ public enum SimmerEvents implements Serializable, IsSerializable {
     CIRCUIT_BROKEN_NO_PATH_FOR_CURRENT_SOURCE("circuit.broken.no-path-for-current-source"),
     CIRCUIT_BROKEN_VOLTAGE_SOURCE_LOOP("circuit.broken.voltage-source-loop"),
     CIRCUIT_BROKEN_CAPACITOR_LOOP("circuit.broken.capacitor-loop"),
-    CIRCUIT_BROKEN_MATRIX_ERROR("circuit.broken.matrix-error");
+    CIRCUIT_BROKEN_MATRIX_ERROR("circuit.broken.matrix-error"),
+    CIRCUIT_STOPPED("circuit.stopped"),
+    SYSTEM_ERROR("system.error");
 
     public final String value;
 


### PR DESCRIPTION
2 new events: CIRCUIT_STOPPED and SYSTEM_ERROR.
Because a circuit may be broken but simulation is not stopped. If simulation is stopped, user should restart it manually. System errors are not related to the circuit and simulation.

For errors related with components or nodes information
about component or note is sent in the error event
Data sent in error:
- Localized message
- Element name like com.joebotics.simmer.client.elcomp.LEDElm@28 (if error is component related)
- Node x and y position (if error is node related)

@jmaisel please review the request. Should I send more information to the bus or this one is enough?